### PR TITLE
Current BP visual styling, fixes

### DIFF
--- a/www/css/youtube.css
+++ b/www/css/youtube.css
@@ -169,6 +169,15 @@ label.duration {
     background: #adadad !important;
 }
 
+/* The indicator of segments that have been passed */
+.bottom_player .played {
+    height: 5px;
+    position: absolute;
+    background: #3a1e94;
+    margin-top: 5px;
+    z-index: 10;
+}
+
 /* Breakpoint styling */
 ul.player_breakpoints {
     position: relative;

--- a/www/js/controllers.js
+++ b/www/js/controllers.js
@@ -1,5 +1,5 @@
 
-angular.module('breakpoint.controllers', ['breakpoint.services'])
+angular.module('breakpoint.controllers', ['breakpoint.services', 'amliu.timeParser'])
 
 .controller('AppCtrl', function($scope, $ionicModal, $ionicPopup, $sce, $ionicScrollDelegate) {
 	// Opens search popup when search button in nav bar clicked
@@ -91,8 +91,9 @@ angular.module('breakpoint.controllers', ['breakpoint.services'])
 })
 
 
-.controller('VideoCtrl', function($window, $rootScope, $scope, $stateParams, parse) {
-	$scope.Math = window.Math;
+.controller('VideoCtrl', function($window, $rootScope, $scope, $stateParams, parse, timeParser) {
+
+    $scope.timeParser = timeParser;
 
     $scope.videoId = $stateParams.videoId;
 

--- a/www/js/directives.js
+++ b/www/js/directives.js
@@ -239,6 +239,7 @@ angular.module('breakpoint.directives', ['breakpoint.services', 'amliu.timeParse
         // to that location in seconds
         scope.setToSpot = function() {
             scope.player.seekTo(scope.currentTime, true);
+            positionPlayedSegments(); // TODO -> MOVE THIS OUT LATER. Could probably do better in the watch above
         }
 
 
@@ -291,6 +292,15 @@ angular.module('breakpoint.directives', ['breakpoint.services', 'amliu.timeParse
                 var position = Math.floor((breakpoint.get("time") / scope.duration) * bottomplayer_width);
                 var breakpointEl = angular.element(document.querySelector("#"+breakpoint.id)).css("left", position+"px");
             }
+        }
+
+        // Repositions the darker violet bar that indicates already played/passed segments
+        function positionPlayedSegments() {
+            var bottomplayer_width = document.querySelector("youtube#"+scope.videoid+" .bottom_player input").offsetWidth;
+            findCurrent(scope.currentTime);
+            var breakpoint = scope.breakpoints[scope.currentBp];
+            var playedWidth = Math.floor( (breakpoint.get("time") / scope.duration) * bottomplayer_width);
+            angular.element(document.querySelector("youtube#"+scope.videoid+" .bottom_player .played")).css("width", playedWidth+"px");
         }
 
     }  

--- a/www/js/directives.js
+++ b/www/js/directives.js
@@ -20,7 +20,7 @@ angular.module('breakpoint.directives', ['breakpoint.services', 'amliu.timeParse
       duration: "=", // Duration of the YT video in seconds
       duration_formatted: "=", // Duration of video formatted
 
-      currentBp: "=", // Current BP
+      currentBp: "=", // Current BP as an index in the BP array
 
       currentTime: "=", // Current time in seconds
       currentTime_formatted: "=", // Current time that's been formated 00:00:00
@@ -164,13 +164,13 @@ angular.module('breakpoint.directives', ['breakpoint.services', 'amliu.timeParse
         }
 
         scope.forwardPlayer = function forwardPlayer() {
-            increaseCurrent();
+            increaseCurrent(scope.player.getCurrentTime());
             scope.player.seekTo(scope.breakpoints[scope.currentBp].get("time"), true);
             scope.currentTime = scope.player.getCurrentTime();
         }
 
         scope.backPlayer = function backPlayer() {
-            decreaseCurrent();
+            decreaseCurrent(scope.player.getCurrentTime());
             scope.player.seekTo(scope.breakpoints[scope.currentBp].get("time"), true);
             scope.currentTime = scope.player.getCurrentTime();
         }
@@ -229,10 +229,19 @@ angular.module('breakpoint.directives', ['breakpoint.services', 'amliu.timeParse
 
         // Used to watch when 
         scope.$watch("currentTime", function(newValue, oldValue) {
-            console.log(scope.currentTime);
-            if (scope.currentTime > 2) {
-                console.log("AYYYY!!!!");
+            console.log(scope.currentBp);
+            console.log(scope.breakpoints[scope.currentBp + 1].get("time"));
+            if (scope.currentBp >= scope.breakpoints.length - 1) { // On the last segment
+
+            } else {
+                if (scope.currentTime > scope.breakpoints[scope.currentBp + 1].get("time")) {
+                    console.log("Passed a breapoint!");
+                }
             }
+        })
+
+        scope.$watch("currentBp", function(newValue, oldValue) {
+            console.log("Changed BP");
         })
 
         // Used in the bottom player slider to get input from slider and set the video
@@ -247,11 +256,15 @@ angular.module('breakpoint.directives', ['breakpoint.services', 'amliu.timeParse
         // --------------------------------------------------
         // METHODS
 
-        function increaseCurrent() {
+        function increaseCurrent(currentTime) {
+            if (currentTime < scope.breakpoints[0].get("time")) {
+                scope.currentBp = 0;
+                return;
+            }
             scope.currentBp++;
             scope.currentBp = scope.currentBp % scope.breakpoints.length;
         }
-        function decreaseCurrent() {
+        function decreaseCurrent(currentTime) {
             scope.currentBp--;
             if (scope.currentBp < 0) {
                 scope.currentBp = scope.breakpoints.length - 1;
@@ -269,7 +282,12 @@ angular.module('breakpoint.directives', ['breakpoint.services', 'amliu.timeParse
                 return currentTime >= currBP;
             }
         }
+
         function findCurrent(currentTime) {
+            if (currentTime < scope.breakpoints[0].get("time")) {
+                scope.currentBp = 0;
+                return;
+            }
             for (var i = 0; i < scope.breakpoints.length; i++) {
                 if (i === scope.breakpoints.length - 1) {
                     scope.currentBp = scope.breakpoints.length - 1;

--- a/www/js/directives.js
+++ b/www/js/directives.js
@@ -188,6 +188,8 @@ angular.module('breakpoint.directives', ['breakpoint.services', 'amliu.timeParse
         }
 
         scope.fullscreen = function fullscreen() {
+            positionBreakpoints();
+
             // Parent of the youtube tag is the scroller container. We use ID to ensure we grab the currently viewed page
             angular.element(document.getElementById(scope.videoid).parentNode).addClass("no-scroll");
 
@@ -224,13 +226,21 @@ angular.module('breakpoint.directives', ['breakpoint.services', 'amliu.timeParse
             })
             scope.currentTime_timeoutId = setTimeout(refreshCurrentTime, 250);
         }
-        
+
+        // Used to watch when 
         scope.$watch("currentTime", function(newValue, oldValue) {
             console.log(scope.currentTime);
             if (scope.currentTime > 2) {
                 console.log("AYYYY!!!!");
             }
         })
+
+        // Used in the bottom player slider to get input from slider and set the video
+        // to that location in seconds
+        scope.setToSpot = function() {
+            scope.player.seekTo(scope.currentTime, true);
+        }
+
 
 
         // --------------------------------------------------

--- a/www/templates/video.html
+++ b/www/templates/video.html
@@ -30,7 +30,7 @@
 
         <table class="breakpoint-table">
             <tr ng-repeat="breakpoint in breakpoints">
-                <td class="time-cell">{{ Math.floor(breakpoint.attributes.time / 60) }}:{{ breakpoint.attributes.time % 60 }}</td>
+                <td class="time-cell">{{ timeParser.convertSeconds(breakpoint.attributes.time) }}</td>
                 <td class="step-description-cell">
                     <h5> {{ breakpoint.attributes.title }}</h5>
                     <p> {{ breakpoint.attributes.description }}</p>

--- a/www/templates/videoOverlay.html
+++ b/www/templates/videoOverlay.html
@@ -47,7 +47,7 @@
             <ul class="player_breakpoints">
                 <li ng-repeat="breakpoint in breakpoints" id="{{ breakpoint.id }}"></li>
             </ul>
-            <input type="range" min="0" max="{{ duration }}" step="0.2" ng-model=" currentTime">
+            <input type="range" min="0" max="{{ duration }}" step="0.2" ng-model=" currentTime" ng-change="setToSpot()">
             <div class="progress"></div>
         </div>
 

--- a/www/templates/videoOverlay.html
+++ b/www/templates/videoOverlay.html
@@ -44,6 +44,7 @@
         <a class="compress" href="javascript:;" ng-click="leave_fullscreen()"><fa name="compress"></fa></a>
         <label class="duration" ng-bind="duration_formatted"></label>
         <span class="bottom_player">
+            <div class="played"></div>
             <ul class="player_breakpoints">
                 <li ng-repeat="breakpoint in breakpoints" id="{{ breakpoint.id }}"></li>
             </ul>


### PR DESCRIPTION
- Fixed formatting of when breakpoints occur on the video show page
- Added a darkened player bar (a slider) that shows already "played" but not currently focused breakpoint segments
- Styling for above, and updating the current time based on input from the slider when you drag the dot thing around
- Bug fix where current time and current BP would get out of sync and really messed up
